### PR TITLE
Fixes and updates to RadialDistributionFunction class

### DIFF
--- a/pymatgen_diffusion/aimd/tests/test_van_hove.py
+++ b/pymatgen_diffusion/aimd/tests/test_van_hove.py
@@ -66,6 +66,16 @@ class RDFTest(unittest.TestCase):
         rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], rmax=5.0, sigma=0.1, ngrid=500 )
         self.assertEqual( rdf.coordination_number[100], 6.0 )
 
+    def test_rdf_two_species_coordination_number(self):
+        # create a structure with interpenetrating simple cubic lattice
+        coords = np.array( [ [ 0.0, 0.0, 0.0 ],
+                             [ 0.5, 0.5, 0.5 ] ] )
+        atom_list = [ 'S', 'Zn' ]
+        lattice = Lattice.from_parameters( a=1.0, b=1.0, c=1.0, alpha=90, beta=90, gamma=90 )
+        structure = Structure( lattice, atom_list, coords )
+        rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], reference_species=['Zn'], rmax=5.0, sigma=0.1, ngrid=500 )
+        self.assertEqual( rdf.coordination_number[100], 8.0 )
+ 
 class EvolutionAnalyzerTest(unittest.TestCase):
     def test_get_df(self):
         data_file = os.path.join(tests_dir, "cNa3PS4_pda.json")

--- a/pymatgen_diffusion/aimd/tests/test_van_hove.py
+++ b/pymatgen_diffusion/aimd/tests/test_van_hove.py
@@ -64,7 +64,7 @@ class RDFTest(unittest.TestCase):
         lattice = Lattice.from_parameters( a=1.0, b=1.0, c=1.0, alpha=90, beta=90, gamma=90 )
         structure = Structure( lattice, atom_list, coords )
         rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], rmax=5.0, sigma=0.1, ngrid=500 )
-        self.assertEqual( rdf.coordination_number[101], 6.0 )
+        self.assertEqual( rdf.coordination_number[100], 6.0 )
 
     def test_rdf_two_species_coordination_number(self):
         # create a structure with interpenetrating simple cubic lattice
@@ -74,7 +74,7 @@ class RDFTest(unittest.TestCase):
         lattice = Lattice.from_parameters( a=1.0, b=1.0, c=1.0, alpha=90, beta=90, gamma=90 )
         structure = Structure( lattice, atom_list, coords )
         rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], reference_species=['Zn'], rmax=5.0, sigma=0.1, ngrid=500 )
-        self.assertEqual( rdf.coordination_number[101], 8.0 )
+        self.assertEqual( rdf.coordination_number[100], 8.0 )
 
     def setUp(self):
         coords = np.array( [ [ 0.5, 0.5, 0.5 ] ] )

--- a/pymatgen_diffusion/aimd/tests/test_van_hove.py
+++ b/pymatgen_diffusion/aimd/tests/test_van_hove.py
@@ -4,7 +4,6 @@
 
 from __future__ import division, unicode_literals, print_function
 from pymatgen import Structure, Lattice
-from unittest.mock import Mock
 
 __author__ = "Iek-Heng Chu"
 __version__ = 1.0

--- a/pymatgen_diffusion/aimd/tests/test_van_hove.py
+++ b/pymatgen_diffusion/aimd/tests/test_van_hove.py
@@ -4,6 +4,7 @@
 
 from __future__ import division, unicode_literals, print_function
 from pymatgen import Structure, Lattice
+from unittest.mock import Mock
 
 __author__ = "Iek-Heng Chu"
 __version__ = 1.0
@@ -75,7 +76,30 @@ class RDFTest(unittest.TestCase):
         structure = Structure( lattice, atom_list, coords )
         rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], reference_species=['Zn'], rmax=5.0, sigma=0.1, ngrid=500 )
         self.assertEqual( rdf.coordination_number[101], 8.0 )
- 
+
+    def setUp(self):
+        coords = np.array( [ [ 0.5, 0.5, 0.5 ] ] )
+        atom_list = [ 'S' ]
+        lattice = Lattice.from_parameters( a=1.0, b=1.0, c=1.0, alpha=90, beta=90, gamma=90 )
+        self.structure = Structure( lattice, atom_list, coords )
+
+    def test_raises_valueerror_if_ngrid_is_less_than_2(self):
+        with self.assertRaises( ValueError ):
+            rdf = RadialDistributionFunction( structures=[ self.structure ], ngrid=1 )
+
+    def test_raises_ValueError_if_sigma_is_not_positive(self):
+        with self.assertRaises( ValueError ):
+            rdf = RadialDistributionFunction( structures=[ self.structure ], sigma=0 )
+
+    def test_raises_ValueError_if_species_not_in_structure(self):
+        with self.assertRaises( ValueError ):
+            rdf = RadialDistributionFunction( structures=[ self.structure ], species=['Cl'] )
+         
+    def test_raises_ValueError_if_reference_species_not_in_structure(self):
+        with self.assertRaises( ValueError ):
+            rdf = RadialDistributionFunction( structures=[ self.structure ], species=['S'],
+                reference_species=['Cl'] )
+
 class EvolutionAnalyzerTest(unittest.TestCase):
     def test_get_df(self):
         data_file = os.path.join(tests_dir, "cNa3PS4_pda.json")

--- a/pymatgen_diffusion/aimd/tests/test_van_hove.py
+++ b/pymatgen_diffusion/aimd/tests/test_van_hove.py
@@ -55,7 +55,7 @@ class RDFTest(unittest.TestCase):
 
         check = np.shape(obj.rdf)[0] == 101 and np.argmax(obj.rdf) == 34
         self.assertTrue(check)
-        self.assertAlmostEqual(obj.rdf.max(), 1.6831, 4)
+        self.assertAlmostEqual(obj.rdf.max(), 1.634448, 4)
 
     def test_rdf_coordination_number(self):
         # create a simple cubic lattice
@@ -64,7 +64,7 @@ class RDFTest(unittest.TestCase):
         lattice = Lattice.from_parameters( a=1.0, b=1.0, c=1.0, alpha=90, beta=90, gamma=90 )
         structure = Structure( lattice, atom_list, coords )
         rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], rmax=5.0, sigma=0.1, ngrid=500 )
-        self.assertEqual( rdf.coordination_number[100], 6.0 )
+        self.assertEqual( rdf.coordination_number[101], 6.0 )
 
     def test_rdf_two_species_coordination_number(self):
         # create a structure with interpenetrating simple cubic lattice
@@ -74,7 +74,7 @@ class RDFTest(unittest.TestCase):
         lattice = Lattice.from_parameters( a=1.0, b=1.0, c=1.0, alpha=90, beta=90, gamma=90 )
         structure = Structure( lattice, atom_list, coords )
         rdf = RadialDistributionFunction( structures=[ structure ], species=['S'], reference_species=['Zn'], rmax=5.0, sigma=0.1, ngrid=500 )
-        self.assertEqual( rdf.coordination_number[100], 8.0 )
+        self.assertEqual( rdf.coordination_number[101], 8.0 )
  
 class EvolutionAnalyzerTest(unittest.TestCase):
     def test_get_df(self):
@@ -91,8 +91,7 @@ class EvolutionAnalyzerTest(unittest.TestCase):
         atom_dist = eva.get_df(EvolutionAnalyzer.atom_dist, specie="Na", direction="c")
         check = np.shape(rdf) == (10, 101) and np.shape(atom_dist) == (10, 101) and eva.pairs[0] == ("Na", "Na")
         self.assertTrue(check)
-        self.assertAlmostEqual(max(np.array(rdf)[0]), 1.82363640047, 4)
-
+        self.assertAlmostEqual(max(np.array(rdf)[0]), 1.772465, 4)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pymatgen_diffusion/aimd/van_hove.py
+++ b/pymatgen_diffusion/aimd/van_hove.py
@@ -293,8 +293,8 @@ class RadialDistributionFunction(object):
                 with supercell. Default is 1, i.e. including the adjecent image
                 cells along all three directions.
             sigma (float): Smearing of a Gaussian function.
-            species ([string]): A list of specie symbols of interest.
-            reference_species ([string]): set this option along with 'species'
+            species (list[string]): A list of specie symbols of interest.
+            reference_species (list[string]): set this option along with 'species'
                 parameter to compute pair radial distribution function.
                 eg: species=["H"], reference_species=["O"] to compute
                     O-H pair distribution in a water MD simulation.
@@ -309,10 +309,11 @@ class RadialDistributionFunction(object):
 
         assert len(indices) > 0, "Given species are not in the structure!"
 
-        ref_indices = indices
         if reference_species:
             ref_indices = [j for j, site in enumerate(structures[0])
                            if site.specie.symbol in reference_species]
+        else:
+            ref_indices = indices
 
         self.rho = float(len(indices)) / lattice.volume
         fcoords_list = []
@@ -327,6 +328,7 @@ class RadialDistributionFunction(object):
         interval = np.linspace(0.0, rmax, ngrid)
         rdf = np.zeros((ngrid), dtype=np.double)
         raw_rdf = np.zeros((ngrid), dtype=np.double)
+
         dns = Counter()
 
         # generate the translational vectors
@@ -349,7 +351,7 @@ class RadialDistributionFunction(object):
             d2 = np.sum(dcc ** 2, axis=3)
             dists = [d2[u, v, j] ** 0.5 for u in range(len(indices)) for v in
                      range(len(ref_indices))
-                     for j in range(len(r) ** 3) if u != v or j != indx0]
+                     for j in range(len(r) ** 3) if indices[u] != ref_indices[v] or j != indx0]
             dists = filter(lambda e: e < rmax + 1e-8, dists)
             r_indices = [int(dist / dr) for dist in dists]
             dns.update(r_indices)

--- a/pymatgen_diffusion/aimd/van_hove.py
+++ b/pymatgen_diffusion/aimd/van_hove.py
@@ -389,8 +389,9 @@ class RadialDistributionFunction(object):
         Returns:
             numpy array
         """
-        return np.cumsum(self.raw_rdf[:-1] * self.rho * 4.0/3.0 * np.pi * 
-                         ( self.interval[1:] ** 3 - self.interval[:-1] ** 3 ) )
+        intervals = np.append( self.interval, self.interval[-1] + self.dr )
+        return np.cumsum(self.raw_rdf * self.rho * 4.0/3.0 * np.pi * 
+                         ( intervals[1:] ** 3 - intervals[:-1] ** 3 ) )
 
     def get_rdf_plot(self, label=None, xlim=(0.0, 8.0), ylim=(-0.005, 3.0)):
         """

--- a/pymatgen_diffusion/aimd/van_hove.py
+++ b/pymatgen_diffusion/aimd/van_hove.py
@@ -359,14 +359,11 @@ class RadialDistributionFunction(object):
         for indx, dn in dns.most_common(ngrid):
             if indx > len(interval) - 1: continue
 
-            if indx == 0:
-                ff = np.pi * dr ** 2
-            else:
-                ff = 4.0 * np.pi * interval[indx] ** 2
+            ff = 4.0 / 3.0 * np.pi * ( interval[indx+1] ** 3 - interval[indx] ** 3 ) 
 
             rdf[:] += stats.norm.pdf(interval, interval[indx], sigma) * dn \
-                      / float(len(ref_indices)) / ff / self.rho / len(
-                fcoords_list)
+                      / float(len(ref_indices)) / ff / self.rho / len(fcoords_list) * dr
+                      # additional dr factor renormalises overlapping gaussians.
             raw_rdf[indx] += dn / float(len(ref_indices)) / ff / self.rho / len(fcoords_list)
 
         self.structures = structures
@@ -387,7 +384,8 @@ class RadialDistributionFunction(object):
         Returns:
             numpy array
         """
-        return np.cumsum(self.raw_rdf * self.rho * 4.0 * np.pi * self.interval ** 2)
+        return np.cumsum(self.raw_rdf[:-1] * self.rho * 4.0/3.0 * np.pi * 
+                         ( self.interval[1:] ** 3 - self.interval[:-1] ** 3 ) )
 
     def get_rdf_plot(self, label=None, xlim=(0.0, 8.0), ylim=(-0.005, 3.0)):
         """

--- a/pymatgen_diffusion/aimd/van_hove.py
+++ b/pymatgen_diffusion/aimd/van_hove.py
@@ -300,18 +300,23 @@ class RadialDistributionFunction(object):
                     O-H pair distribution in a water MD simulation.
         """
 
-        assert ngrid >= 1, "ngrid should be greater than 1!"
-        assert sigma > 0, "sigma should be a positive number!"
+        if ngrid < 2:
+            raise ValueError( "ngrid should be greater than 1!" )
+        if sigma <= 0:
+            raise ValueError( "sigma should be a positive number!" )
 
         lattice = structures[0].lattice
         indices = [j for j, site in enumerate(structures[0])
                    if site.specie.symbol in species]
 
-        assert len(indices) > 0, "Given species are not in the structure!"
+        if len(indices) < 1:
+            raise ValueError( "Given species are not in the structure!" )
 
         if reference_species:
             ref_indices = [j for j, site in enumerate(structures[0])
                            if site.specie.symbol in reference_species]
+            if len(ref_indices) < 1:
+                raise ValueError( "Given reference species are not in the structure!" )
         else:
             ref_indices = indices
 


### PR DESCRIPTION
* Fixes a bug in the RDF pair distribution function when the reference species != the main species.
* Updated volume scaling in the RDF calculation to use exact volumes.
* `RadialDistributionFunction()` argument checks now raise `ValueError`s if failed.