### PR TITLE
2 small modifications

### DIFF
--- a/pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py
+++ b/pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py
@@ -47,10 +47,9 @@ class MigrationGraphFromEntriesTest(unittest.TestCase):
         self.test_ents_MOF = loadfn(f"{dir_path}/full_path_files/Mn6O5F7_cat_migration.json")
         self.aeccar_MOF = Chgcar.from_file(f"{dir_path}/full_path_files/AECCAR_Mn6O5F7.vasp")
         self.li_ent = loadfn(f"{dir_path}/full_path_files/li_ent.json")["li_ent"]
-
+        entries = [self.test_ents_MOF["ent_base"]] + self.test_ents_MOF["one_cation"]
         self.full_struct = MigrationGraph.get_structure_from_entries(
-            base_entries=[self.test_ents_MOF["ent_base"]],
-            inserted_entries=self.test_ents_MOF["one_cation"],
+            entries=entries,
             migrating_ion_entry=self.li_ent,
         )[0]
 

--- a/pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py
+++ b/pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py
@@ -53,6 +53,20 @@ class MigrationGraphFromEntriesTest(unittest.TestCase):
             migrating_ion_entry=self.li_ent,
         )[0]
 
+    def test_m_graph_from_entries_failed(self):
+        # only base
+        s_list = MigrationGraph.get_structure_from_entries(
+            entries=[self.test_ents_MOF["ent_base"]],
+            migrating_ion_entry=self.li_ent,
+        )
+        self.assertEqual(len(s_list), 0)
+
+        s_list = MigrationGraph.get_structure_from_entries(
+            entries=self.test_ents_MOF["one_cation"],
+            migrating_ion_entry=self.li_ent,
+        )
+        self.assertEqual(len(s_list), 0)
+
     def test_m_graph_construction(self):
         self.assertEqual(self.full_struct.composition["Li"], 8)
         mg = MigrationGraph.with_distance(self.full_struct, migrating_specie="Li", max_distance=4.0)

--- a/pymatgen/analysis/diffusion/utils/maggma.py
+++ b/pymatgen/analysis/diffusion/utils/maggma.py
@@ -7,13 +7,6 @@ cathode materials The functions are isolated from the rest of the package so
 that the rest of the package will not depend on Maggma
 """
 
-import logging
-from typing import Union
-
-from maggma.stores import MongoStore
-from monty.serialization import MontyDecoder
-from pymatgen.entries.compatibility import MaterialsProjectCompatibility
-
 __author__ = "Jimmy Shen"
 __copyright__ = "Copyright 2019, The Materials Project"
 __version__ = "0.1"
@@ -21,14 +14,20 @@ __maintainer__ = "Jimmy Shen"
 __email__ = "jmmshn@lbl.gov"
 __date__ = "July 21, 2019"
 
+import logging
+from typing import Union
+
+from maggma.stores import MongoStore
+from monty.serialization import MontyDecoder
 from pymatgen.entries.computed_entries import ComputedEntry
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-compat = MaterialsProjectCompatibility("Advanced")
 
 
-def get_entries_from_dbs(structure_group_store: MongoStore, material_store: MongoStore, material_id: Union[str, int]):
+def get_entries_from_dbs(
+    structure_group_store: MongoStore, material_store: MongoStore, migrating_ion: str, material_id: Union[str, int]
+):
     """
     Get the entries needed to construct a migration from a database that
     contains topotactically matched structures.
@@ -38,16 +37,17 @@ def get_entries_from_dbs(structure_group_store: MongoStore, material_store: Mong
             insertion materials, can also use any db that contains a
         material_store: Material documenets one per each similar structure (
             multiple tasks)
+        migrating_ion: The name of the migrating ion
         material_ids list with topotactic structures
     """
 
     with structure_group_store as store:
-        sg_doc = store.query_one({"material_id": material_id})
-    ignored_species = sg_doc["ignored_species"][0]
+        sg_doc = store.query_one({structure_group_store.key: material_id})
+    ignored_species = migrating_ion
     base_entries = []
     inserted_entries = []
     with material_store as store:
-        for m_doc in store.query({"material_id": {"$in": sg_doc["grouped_ids"]}}):
+        for m_doc in store.query({"material_id": {"$in": sg_doc["material_ids"]}}):
             if "GGA+U" in m_doc["entries"]:
                 entry = MontyDecoder().process_decoded(m_doc["entries"]["GGA+U"])  # type: ComputedEntry
             elif "GGA" in m_doc["entries"]:

--- a/pymatgen/analysis/diffusion/utils/parse_entries.py
+++ b/pymatgen/analysis/diffusion/utils/parse_entries.py
@@ -41,8 +41,8 @@ def process_entries(
 ) -> List[Dict]:
     """
     Process a list of base entries and inserted entries to create input for migration path analysis Each inserted
-    entries can be mapped to more than one base entry. Return groups of inserted entries based ranked by the number
-    of inserted entries in each group
+    entries can be mapped to more than one base entry. Return groups of structures decorated with the working ions
+    to indicate the metastable sites, ranked by the number of working ion sites (highest number is the first).
 
     Args:
         base_entries: Full list of base entires

--- a/pymatgen/analysis/diffusion/utils/parse_entries.py
+++ b/pymatgen/analysis/diffusion/utils/parse_entries.py
@@ -103,13 +103,17 @@ def process_entries(
 
     for base_ent, _ in entries_with_num_symmetry_ops:
         # structure where the
-        mapped_based_cell = base_ent.structure.copy()
+        mapped_cell = base_ent.structure.copy()
         for j_inserted in inserted_entries:
             inserted_sites_ = _meta_stable_sites(base_ent, j_inserted)
-            mapped_based_cell.sites.extend(inserted_sites_)
+            mapped_cell.sites.extend(inserted_sites_)
 
-        struct_wo_sym_ops = _filter_and_merge(mapped_based_cell.get_sorted_structure())
+        struct_wo_sym_ops = _filter_and_merge(mapped_cell.get_sorted_structure())
         if struct_wo_sym_ops is None:
+            logger.warning(
+                f"No meta-stable sites were found during symmetry mapping for base {base_ent.entry_id}."
+                "Consider playing with the various tolerances (ltol, stol, angle_tol)."
+            )
             continue
 
         struct_sym = get_sym_migration_ion_sites(base_ent.structure, struct_wo_sym_ops, working_ion)

--- a/pymatgen/analysis/diffusion/utils/parse_entries.py
+++ b/pymatgen/analysis/diffusion/utils/parse_entries.py
@@ -6,7 +6,7 @@
 Functions for combining many ComputedEntry objects into MigrationGraph objects.
 """
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 from pymatgen.core import Composition, Lattice, Structure
@@ -109,6 +109,9 @@ def process_entries(
             mapped_based_cell.sites.extend(inserted_sites_)
 
         struct_wo_sym_ops = _filter_and_merge(mapped_based_cell.get_sorted_structure())
+        if struct_wo_sym_ops is None:
+            continue
+
         struct_sym = get_sym_migration_ion_sites(base_ent.structure, struct_wo_sym_ops, working_ion)
         results.append(
             {
@@ -243,7 +246,7 @@ def get_sym_migration_ion_sites(
     return sym_migration_struct
 
 
-def _filter_and_merge(inserted_structure: Structure):
+def _filter_and_merge(inserted_structure: Structure) -> Union[Structure, None]:
     """
     For each site in a structure, split it into a migration sublattice where all sites contain the "insertion_energy"
     property and a host lattice. For each site in the migration sublattice if there is collision with the host sites,
@@ -256,6 +259,8 @@ def _filter_and_merge(inserted_structure: Structure):
             migration_sites.append(i_site)
         else:
             base_sites.append(i_site)
+    if len(migration_sites) == 0:
+        return None
     migration = Structure.from_sites(migration_sites)
     base = Structure.from_sites(base_sites)
 

--- a/pymatgen/analysis/diffusion/utils/tests/test_files/maggma_sgroup_store.json
+++ b/pymatgen/analysis/diffusion/utils/tests/test_files/maggma_sgroup_store.json
@@ -5,10 +5,10 @@
       "@class": "ObjectId",
       "oid": "604a730faa253394b1f97085"
     },
-    "material_id": "mvc-6910_Mg",
+    "group_id": "mvc-6910_Mg",
     "structure_matched": true,
     "has_distinct_compositions": true,
-    "grouped_ids": [
+    "material_ids": [
       "mvc-6910",
       "mp-1245011"
     ],

--- a/pymatgen/analysis/diffusion/utils/tests/test_maggma.py
+++ b/pymatgen/analysis/diffusion/utils/tests/test_maggma.py
@@ -18,14 +18,14 @@ __date__ = "April 10, 2019"
 @pytest.fixture
 def maggma_stores():
     return {
-        "sgroups": JSONStore(f"{dir_path}/maggma_sgroup_store.json", key="material_id"),
+        "sgroups": JSONStore(f"{dir_path}/maggma_sgroup_store.json", key="group_id"),
         "materials": JSONStore(f"{dir_path}/maggma_materials_store.json", key="material_id"),
     }
 
 
 def test(maggma_stores):
     base_ents, inserted_ents = get_entries_from_dbs(
-        maggma_stores["sgroups"], maggma_stores["materials"], material_id="mvc-6910_Mg"
+        maggma_stores["sgroups"], maggma_stores["materials"], "Mg", material_id="mvc-6910_Mg"
     )
 
     # check that the entries have been created


### PR DESCRIPTION
## Modified get_structure_from_entries
Since the `migrating_ion_entry` is provided, we don't need to split the base and inserted entries in the input to `get_structure_from_entries`
The changes are in these files:

> pymatgen/analysis/diffusion/utils/parse_entries.py
> pymatgen/analysis/diffusion/neb/full_path_mapper.py
> pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py

## Changed the key name in the maggma help function.

The changes are in these files:

> pymatgen/analysis/diffusion/utils/maggma.py
> pymatgen/analysis/diffusion/utils/tests/test_files/maggma_sgroup_store.json
> pymatgen/analysis/diffusion/utils/tests/test_maggma.py