### PR TITLE
Remove magmom

### DIFF
--- a/pymatgen/analysis/diffusion/neb/full_path_mapper.py
+++ b/pymatgen/analysis/diffusion/neb/full_path_mapper.py
@@ -274,8 +274,7 @@ class MigrationGraph(MSONable):
             # make spglib ignore all magmoms
             for isite in struct.sites:
                 isite.properties.pop("magmom", None)
-
-            res.append(Structure.from_sites(all_sites))
+            res.append(struct)
         return res
 
     def _get_pos_and_migration_hop(self, u, v, w):

--- a/pymatgen/analysis/diffusion/neb/full_path_mapper.py
+++ b/pymatgen/analysis/diffusion/neb/full_path_mapper.py
@@ -270,6 +270,11 @@ class MigrationGraph(MSONable):
             all_sites = group["base"].copy().sites
             for isite in group["inserted"]:
                 all_sites.append(isite)
+            struct = Structure.from_sites(all_sites)
+            # make spglib ignore all magmoms
+            for isite in struct.sites:
+                isite.properties.pop("magmom", None)
+
             res.append(Structure.from_sites(all_sites))
         return res
 


### PR DESCRIPTION
Since we are using a structure full of fake sites, I think the magmom values are kind of meaningless.
Removing them here also ensures that the generated structures will never cause problems with spglib's symmetry operations.