### PR TITLE
added optional parameter to track in a given path

### DIFF
--- a/pymatgen/analysis/diffusion/neb/full_path_mapper.py
+++ b/pymatgen/analysis/diffusion/neb/full_path_mapper.py
@@ -733,14 +733,15 @@ def _shift_grid(vv):
     return vv + step / 2.0
 
 
-def get_hop_site_sequence(hop_list: List[Dict], start_u: Union[int, str]) -> List:
+def get_hop_site_sequence(hop_list: List[Dict], start_u: Union[int, str], key: str = None) -> List:
     """
-    Read in a list of hop dictionaries and print the sequence of sites.
+    Read in a list of hop dictionaries and print the sequence of sites (and relevant property values if any).
     Args:
         hop_list: a list of the data on a sequence of hops
         start_u: the site index of the starting sites
+        key (optional): property to track in a hop (e.g.: "hop_distance")
     Returns:
-        String representation of the hop sequence
+        String representation of the hop sequence (and property values if any)
     """
     hops = iter(hop_list)
     ihop = next(hops)
@@ -756,6 +757,14 @@ def get_hop_site_sequence(hop_list: List[Dict], start_u: Union[int, str]) -> Lis
             site_seq.append(ihop["iindex"])
         else:
             raise RuntimeError("The sequence of sites for the path is invalid.")
+
+    if key is not None:
+        key_seq = []
+        hops = iter(hop_list)
+        for ihop in hops:
+            key_seq.append(ihop[key])
+        return [site_seq, key_seq]
+
     return site_seq
 
 

--- a/pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py
+++ b/pymatgen/analysis/diffusion/neb/tests/test_full_path_mapper.py
@@ -178,6 +178,22 @@ class MigrationGraphComplexTest(unittest.TestCase):
         p_strings = {"->".join(map(str, get_hop_site_sequence(ipath, start_u=u))) for u, ipath in paths}
         self.assertIn("1->0->1", p_strings)
 
+    def test_get_key_in_path(self):
+        self.fpm_li.assign_cost_to_graph()  # use 'hop_distance'
+        paths = [*self.fpm_li.get_path()]
+        hop_seq_info = [get_hop_site_sequence(ipath, start_u=u, key="hop_distance") for u, ipath in paths]
+
+        hop_distances = {}
+        for u, ipath in paths:
+            hop_distances[u] = []
+            for hop in ipath:
+                hop_distances[u].append(hop["hop_distance"])
+
+        # Check that the right key and respective values were pulled
+        for u, distances in hop_distances.items():
+            self.assertEqual(distances, hop_seq_info[u][1])
+            print(distances, hop_seq_info[u][1])
+
     def test_not_matching_first(self):
         structure = Structure.from_file(f"{dir_path}/pathfinder_files/Li6MnO4.json")
         fpm_lmo = MigrationGraph.with_distance(structure, "Li", max_distance=4)


### PR DESCRIPTION
This is a small change in "get_hop_site_sequence" if the user wants to track and print the values of a certain property (e.g. hop_distance, energy_barrier) along a given path in addition to the hop site sequence itself. The tests only call this function for printing purposes, so I thought changes to the tests were not necessary.